### PR TITLE
chatgrops#indexの追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'chatgroups#new'
+  root 'chatgroups#index'
   resources :user_search, only: :index
-  resources :chatgroups, except: [:index, :show] do
+  resources :chatgroups, except: :show do
     resources :comments, only: [:index, :create]
   end
 end


### PR DESCRIPTION
# WHAT
・chatgrops#indexの追加
・chatgrops#indexをルートパスに変更
# WHY
コンフリクトの解決の際に誤って消してしまったため。